### PR TITLE
change one import name

### DIFF
--- a/dual_path_network.py
+++ b/dual_path_network.py
@@ -26,7 +26,7 @@ from keras.regularizers import l2
 from keras.utils import conv_utils
 from keras.utils.data_utils import get_file
 from keras.engine.topology import get_source_inputs
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 from keras.applications.imagenet_utils import decode_predictions
 from keras import backend as K
 


### PR DESCRIPTION
## Problem
When I import dual_path_network in my own code,the code raises the bug:
```
ImportError: cannot import name '_obtain_input_shape'
```
So I find the wrong place.In the  29 line of dual_path_network.py:
```
from keras.applications.imagenet_utils import _obtain_input_shape
```
## Solution
I try to use ' keras_applications ' to replace ' keras.applications '.Its work!The all replacement of the 29 line is:
```
from keras_applications.imagenet_utils import _obtain_input_shape
```
The reason is that in keras 2.2.2, the keras.applications.imagenet utils module no longer has the _ obtain_ input _shape method.

I shown this problem in issue last month, but no one reply me. So I pull request.